### PR TITLE
Add ability to specify HTTP response code in spider.sh

### DIFF
--- a/spider.sh
+++ b/spider.sh
@@ -2,6 +2,7 @@
 
 OUTPUT=""
 URL=""
+RESPONSE_CODE="404"
 
 print_title() {
   echo -e "\033[0;32m░▒▓█▓▒░░▒▓█▓▒░░▒▓████████▓▒░░▒▓█▓▒░░▒▓█▓▒░       ░▒▓███████▓▒░░▒▓███████▓▒░ ░▒▓█▓▒░░▒▓███████▓▒░ ░▒▓████████▓▒░░▒▓███████▓▒░  ";
@@ -19,9 +20,10 @@ print_help() {
   echo "Usage: $0 [OPTIONS]"
   echo "This bash script is used to perform a wget operation on a specified URL, logging the output to a specified file. "
   echo "Options: "
-  echo "  --output       Specify the output file to which the log will be written."
-  echo "  --url          Specify the URL to be scanned with wget."
-  echo "  --help         Print this help message and exit."
+  echo "  --output         Specify the output file to which the log will be written."
+  echo "  --url            Specify the URL to be scanned with wget."
+  echo "  --response-code  Specify the HTTP response code to be targeted in the log output."
+  echo "  --help           Print this help message and exit."
 }
 
 while (( "$#" )); do
@@ -32,6 +34,10 @@ while (( "$#" )); do
       ;;
     --url)
       URL="$2"
+      shift 2
+      ;;
+    --response-code)
+      RESPONSE_CODE="$2"
       shift 2
       ;;
     --help)
@@ -51,7 +57,7 @@ fi
 
 print_title;
 
-if [ -n "$OUTPUT" ] && [ -n "$URL" ]; then
+if [ -n "$OUTPUT" ] && [ -n "$URL" ] && [ -n "$RESPONSE_CODE" ]; then
   wget --spider \
     --output-file "$OUTPUT" \
     --execute robots=off \
@@ -62,5 +68,5 @@ if [ -n "$OUTPUT" ] && [ -n "$URL" ]; then
     "$URL"
 
   tput setab 1; tput setaf 2;
-  grep -B 2 ' 404 Not Found' "$OUTPUT" | awk 'NR%2==1'; tput sgr0
+  grep -B 2 " ${RESPONSE_CODE} .*" "$OUTPUT" | awk 'NR%2==1'; tput sgr0
 fi


### PR DESCRIPTION
Enhanced the spider.sh script to allow specification of an HTTP response code, rather than defaulting to 404. This increases flexibility of the script, allowing users to target different HTTP responses in their scan output. Modifications include adjustments to the command-line options, conditions, and the log output interpretation.